### PR TITLE
Fixed a bug that word_no doesn't return in match process when unmatched by topic/that.

### DIFF
--- a/dialogue-engine/src/programy/parser/pattern/nodes/base.py
+++ b/dialogue-engine/src/programy/parser/pattern/nodes/base.py
@@ -614,6 +614,7 @@ class PatternNode(object):
                 if depth == 0:
                     words.check_words()
 
+                org_word_no = word_no
                 result = child.equals(client_context, words, word_no)
                 if result.matched is True:
                     word_no = result.word_no
@@ -629,9 +630,11 @@ class PatternNode(object):
                         return match, word_no
                     else:
                         context.pop_match()
+                        word_no = org_word_no
         else:
             for child in reversed(children):  # for NLU matching.
 
+                org_word_no = word_no
                 result = child.equals(client_context, words, word_no)
                 if result.matched is True:
                     word_no = result.word_no
@@ -647,6 +650,7 @@ class PatternNode(object):
                         return match, word_no
                     else:
                         context.pop_match()
+                        word_no = org_word_no
 
         return None, word_no
 


### PR DESCRIPTION
In addition to adding a confirmation test for event avoidance, we conducted all exhaustive tests and confirmed that there were no problems.
The test documents and test results are stored in "#0022_failed_get_star" on the shared drive.